### PR TITLE
add getDataPtr method

### DIFF
--- a/src/FlashAsEEPROM.cpp
+++ b/src/FlashAsEEPROM.cpp
@@ -56,6 +56,12 @@ void EEPROMClass::init()
   _initialized = true;
 }
 
+uint8_t * EEPROMClass::getDataPtr()
+{
+    _dirty = true;
+    return _eeprom.data;
+}
+
 bool EEPROMClass::isValid()
 {
   if (!_initialized) init();

--- a/src/FlashAsEEPROM.cpp
+++ b/src/FlashAsEEPROM.cpp
@@ -58,6 +58,7 @@ void EEPROMClass::init()
 
 uint8_t * EEPROMClass::getDataPtr()
 {
+    if (!_initialized) init();
     _dirty = true;
     return _eeprom.data;
 }

--- a/src/FlashAsEEPROM.h
+++ b/src/FlashAsEEPROM.h
@@ -60,6 +60,11 @@ class EEPROMClass {
      */
     void update(int, uint8_t);
 
+    /*
+     * Returns the pointer to the eeprom data.
+     **/
+    uint8_t* getDataPtr();
+    
     /**
      * Check whether the eeprom data is valid
      * @return true, if eeprom data is valid (has been written at least once), false if not


### PR DESCRIPTION
This improved compatibility to EEPROM emulation of ESP8266 which makes it easier to share code between both cpus.