### PR TITLE
Optimize Flash write function to avoid redundant writes

### DIFF
--- a/src/FlashStorage.cpp
+++ b/src/FlashStorage.cpp
@@ -93,12 +93,13 @@ void FlashClass::write(const volatile void *flash_ptr, const void *data, uint32_
     while (NVMCTRL->INTFLAG.bit.READY == 0) { }
 #endif
 
-   // Fill page buffer
+    // Fill page buffer
     uint32_t i;
-    for (i=0; i<(PAGE_SIZE/4) && size; i++) {
-      uint32_t current_value = *dst_addr; // When Buffer already contains Value do not overwrite
+    for (i = 0; i < (PAGE_SIZE / 4) && size; i++)
+    {
       uint32_t new_value = read_unaligned_uint32(src_addr);
-      if (current_value != new_value) {
+      if (*dst_addr != new_value)
+      {
         *dst_addr = new_value;
       }
       src_addr += 4;

--- a/src/FlashStorage.cpp
+++ b/src/FlashStorage.cpp
@@ -93,10 +93,14 @@ void FlashClass::write(const volatile void *flash_ptr, const void *data, uint32_
     while (NVMCTRL->INTFLAG.bit.READY == 0) { }
 #endif
 
-    // Fill page buffer
+   // Fill page buffer
     uint32_t i;
     for (i=0; i<(PAGE_SIZE/4) && size; i++) {
-      *dst_addr = read_unaligned_uint32(src_addr);
+      uint32_t current_value = *dst_addr; // When Buffer already contains Value do not overwrite
+      uint32_t new_value = read_unaligned_uint32(src_addr);
+      if (current_value != new_value) {
+        *dst_addr = new_value;
+      }
       src_addr += 4;
       dst_addr++;
       size--;


### PR DESCRIPTION
This optimization helps in enhancing the longevity of the Flash memory.

- Read new value once for comparison and potential write
- Maintain existing functionality and ensure no regressions
